### PR TITLE
feat: delete quant api 및 로그인 유지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "react-scripts": "5.0.0",
         "recharts": "^2.1.8",
         "redux-logger": "^3.0.6",
+        "redux-persist": "^6.0.0",
         "router": "^1.3.6",
         "typescript": "^4.5.5",
         "web-vitals": "^2.1.4"
@@ -14725,6 +14726,14 @@
         "deep-diff": "^0.3.5"
       }
     },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
+    },
     "node_modules/redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
@@ -28120,6 +28129,12 @@
       "requires": {
         "deep-diff": "^0.3.5"
       }
+    },
+    "redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "requires": {}
     },
     "redux-thunk": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-scripts": "5.0.0",
     "recharts": "^2.1.8",
     "redux-logger": "^3.0.6",
+    "redux-persist": "^6.0.0",
     "router": "^1.3.6",
     "typescript": "^4.5.5",
     "web-vitals": "^2.1.4"

--- a/src/apis/createQuantModel.ts
+++ b/src/apis/createQuantModel.ts
@@ -41,6 +41,8 @@ export default async function createQuantModel(
   body: createQuantModelBody,
   token: string
 ) {
+  console.log("test", body);
+
   try {
     const res = await axios.post(endpoint + "/quants/quant", body, {
       headers: {

--- a/src/apis/deleteQuantModel.ts
+++ b/src/apis/deleteQuantModel.ts
@@ -1,0 +1,18 @@
+import axios from "axios";
+
+import { endpoint } from "./endpoint";
+
+export default async function deleteQuantModel(id: string, token: string) {
+  try {
+    const res = await axios.delete(endpoint + "/quants/quant/" + id, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    return res.data;
+  } catch (e) {
+    return e;
+  }
+}

--- a/src/components/PositionedMenu.tsx
+++ b/src/components/PositionedMenu.tsx
@@ -50,30 +50,27 @@ const PositionedMenu = () => {
           horizontal: "left",
         }}
       >
-        <MenuItem onClick={handleClose}>
-          <Link
-            to={"/PersonalProfilePage"}
-            style={{ textDecoration: "none", color: "black" }}
-          >
-            Profile
-          </Link>
-        </MenuItem>
-        <MenuItem onClick={handleClose}>
-          <Link
-            to="/QuantLabPage"
-            style={{ textDecoration: "none", color: "black" }}
-          >
-            Quant Lab
-          </Link>
-        </MenuItem>
-        <MenuItem onClick={handleClose}>
-          <Link
-            to="/SettingsPage"
-            style={{ textDecoration: "none", color: "black" }}
-          >
-            Settings
-          </Link>
-        </MenuItem>
+        <Link
+          to={"/PersonalProfilePage"}
+          style={{ textDecoration: "none", color: "black" }}
+        >
+          <MenuItem onClick={handleClose}>Profile</MenuItem>
+        </Link>
+
+        <Link
+          to="/QuantLabPage"
+          style={{ textDecoration: "none", color: "black" }}
+        >
+          <MenuItem onClick={handleClose}>Quant Lab</MenuItem>
+        </Link>
+
+        <Link
+          to="/SettingsPage"
+          style={{ textDecoration: "none", color: "black" }}
+        >
+          <MenuItem onClick={handleClose}>Settings</MenuItem>
+        </Link>
+
         {isLoggedin ? (
           <MenuItem
             onClick={() => {
@@ -85,14 +82,12 @@ const PositionedMenu = () => {
             Logout
           </MenuItem>
         ) : (
-          <MenuItem onClick={handleClose}>
-            <Link
-              to="/LoginPage"
-              style={{ textDecoration: "none", color: "black" }}
-            >
-              Login
-            </Link>
-          </MenuItem>
+          <Link
+            to="/LoginPage"
+            style={{ textDecoration: "none", color: "black" }}
+          >
+            <MenuItem onClick={handleClose}>Login</MenuItem>
+          </Link>
         )}
       </Menu>
     </>

--- a/src/components/PositionedMenu.tsx
+++ b/src/components/PositionedMenu.tsx
@@ -1,6 +1,5 @@
 import { AccountCircle } from "@material-ui/icons";
 import { IconButton } from "@mui/material";
-import Button from "@mui/material/Button";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import { useState } from "react";
@@ -12,7 +11,9 @@ import { RootState } from "../stores/store";
 
 const PositionedMenu = () => {
   const dispatch = useDispatch();
-  const { isLoggedin } = useSelector((state: RootState) => state.session); // TODO: 하나씩으로 개선
+  const isLoggedin = useSelector(
+    (state: RootState) => state.session.isLoggedin
+  );
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,9 +2,10 @@ import { CssBaseline, ThemeProvider } from "@mui/material";
 import React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
+import { PersistGate } from "redux-persist/integration/react";
 
 import App from "./App";
-import { store } from "./stores/store";
+import { persistor, store } from "./stores/store";
 import { theme } from "./styles/theme";
 
 ReactDOM.render(
@@ -12,7 +13,9 @@ ReactDOM.render(
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <Provider store={store}>
-        <App />
+        <PersistGate loading={null} persistor={persistor}>
+          <App />
+        </PersistGate>
       </Provider>
     </ThemeProvider>
   </React.StrictMode>,

--- a/src/layouts/MainNavigation.tsx
+++ b/src/layouts/MainNavigation.tsx
@@ -40,6 +40,7 @@ const StyledLink = styled(Link)`
   &:hover,
   &:active {
     color: inherit;
+    text-decoration: none;
   }
 `;
 
@@ -58,12 +59,12 @@ const MainNavigation = () => {
       <AppBar position="static" variant="outlined" color="inherit">
         <Toolbar style={{ padding: "0 3px" }}>
           <MainContainer>
-            <RowContainer>
-              <StyledLink to="/">
+            <StyledLink to="/">
+              <RowContainer>
                 <LogoImage src="https://avatars.githubusercontent.com/u/98199739?s=200&v=4" />
-              </StyledLink>
-              <LogoTypography variant="h5">Economicus</LogoTypography>
-            </RowContainer>
+                <LogoTypography variant="h5">Economicus</LogoTypography>
+              </RowContainer>
+            </StyledLink>
 
             <RowContainer>
               <div style={{ margin: "0 20px" }}>

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -23,6 +23,7 @@ const EconomicusLogo = styled("img")({
 
 const LoginPage = () => {
   const dispatch = useDispatch();
+
   const { isLoggedin, loading, error } = useSelector(
     (state: RootState) => state.session
   );
@@ -31,7 +32,7 @@ const LoginPage = () => {
     event.preventDefault();
     const data = new FormData(event.currentTarget);
 
-    const loginInfo = {
+    const loginInfo: { email: string; password: string } = {
       email: data.get("email") as string, // NOTE: 추후 개선 필요?
       password: data.get("password") as string,
     };

--- a/src/pages/QuantLabPage/QuantLabPage.tsx
+++ b/src/pages/QuantLabPage/QuantLabPage.tsx
@@ -49,8 +49,8 @@ export interface IChart {
   id: number;
   model_name: string;
   chart_data: {
-    start_date: string;
-    profit_kospi_data: number[];
+    // start_date: string;
+    // profit_kospi_data: number[];
     profit_rate_data: number[];
   };
 }

--- a/src/pages/QuantLabPage/QuantModelCreation/LabModal/LabModalWithSlider.tsx
+++ b/src/pages/QuantLabPage/QuantModelCreation/LabModal/LabModalWithSlider.tsx
@@ -31,9 +31,14 @@ export const ChangedFinanceConditionName: IChangedFinanceConditionName = {
   roa: "ROA(%)",
   roe: "ROE(%)",
   market_cap: "시가총액(억 원)",
-  activities_operating: "영업현금흐름(억 원)",
-  activities_investing: "투자현금흐름(억 원)",
-  activities_financing: "재무현금흐름(억 원)",
+
+  // activities_operating: "영업현금흐름(억 원)",
+  // activities_investing: "투자현금흐름(억 원)",
+  // activities_financing: "재무현금흐름(억 원)",
+
+  operating: "영업현금흐름(억 원)",
+  investing: "투자현금흐름(억 원)",
+  financing: "재무현금흐름(억 원)",
 };
 
 export default function LabModalWithSlider({

--- a/src/pages/QuantLabPage/QuantModelCreation/QuantModelCreation.tsx
+++ b/src/pages/QuantLabPage/QuantModelCreation/QuantModelCreation.tsx
@@ -68,6 +68,13 @@ export default function ModelCreation({ setModelList }: ModelCreationProps) {
         ])
     );
 
+    const formedFinanceCondition = Object.fromEntries(
+      Object.entries(financeCondition).map(([key, value]) => [
+        key,
+        { min: value.values[0], max: value.values[1] },
+      ])
+    );
+
     if (!token) {
       setError("로그인이 필요한 기능입니다.");
       return;
@@ -82,10 +89,15 @@ export default function ModelCreation({ setModelList }: ModelCreationProps) {
           main_sectors: Object.entries(businessArea)
             .filter(([, value]) => value === true)
             .map(([key]) => key),
-          ...notActivitiesValue,
-          activities: {
-            ...activitiesValue,
-          },
+
+          ...formedFinanceCondition,
+
+          // ...notActivitiesValue,
+          // activities: {
+          //   ...activitiesValue,
+          // },
+
+          // NOTE: 날짜는 어떻게?
           start_date: "2016-04-30T00:00:00.000Z",
           end_date: "2021-04-30T00:00:00.000Z",
         } as createQuantModelBody,
@@ -95,10 +107,18 @@ export default function ModelCreation({ setModelList }: ModelCreationProps) {
 
       if (responseData instanceof Error) throw responseData;
 
-      setModelList((prev) => [
-        ...prev,
-        { id: +new Date(), model_name: modelName, ...responseData },
-      ]);
+      setModelList((prev) => {
+        return [
+          ...prev,
+          // { id: +new Date(), model_name: modelName, ...responseData },
+          {
+            id: responseData["quant_id"],
+            model_name: modelName,
+            ...responseData,
+          },
+        ];
+      });
+
       setModelName(["", 1]);
     } catch (e) {
       setError((e as AxiosError).response?.data.message);
@@ -201,9 +221,11 @@ export interface IFinanceCondition {
   roa: ICheckboxWithSliderInfo;
   roe: ICheckboxWithSliderInfo;
   market_cap: ICheckboxWithSliderInfo;
-  activities_operating: ICheckboxWithSliderInfo;
-  activities_investing: ICheckboxWithSliderInfo;
-  activities_financing: ICheckboxWithSliderInfo;
+
+  // NOTE: activities
+  operating: ICheckboxWithSliderInfo;
+  investing: ICheckboxWithSliderInfo;
+  financing: ICheckboxWithSliderInfo;
 }
 
 export interface ICheckboxWithSliderInfo {
@@ -270,26 +292,6 @@ const initialBusinessArea: IBusinessArea = {
   유틸리티: true,
 };
 
-// const initialFinanceCondetion = {
-//   net_revenue: sliderStateCunstructor(-100, 100),
-//   net_revenue_rate: sliderStateCunstructor(-100, 100),
-//   net_profit: sliderStateCunstructor(-100, 100),
-//   net_profit_rate: sliderStateCunstructor(-100, 100),
-//   de_ratio: sliderStateCunstructor(-100, 100),
-//   per: sliderStateCunstructor(-100, 100),
-//   psr: sliderStateCunstructor(-100, 100),
-//   pbr: sliderStateCunstructor(-100, 100),
-//   pcr: sliderStateCunstructor(-100, 100),
-//   dividend_yield: sliderStateCunstructor(-100, 100),
-//   dividend_payout_ratio: sliderStateCunstructor(-100, 100),
-//   roa: sliderStateCunstructor(-100, 100),
-//   roe: sliderStateCunstructor(-100, 100),
-//   market_cap: sliderStateCunstructor(-100, 100),
-//   activities_operating: sliderStateCunstructor(-100, 100),
-//   activities_investing: sliderStateCunstructor(-100, 100),
-//   activities_financing: sliderStateCunstructor(-100, 100),
-// };
-
 const initialFinanceCondetion = {
   net_revenue: sliderStateCunstructor(-36, 2437714),
   net_revenue_rate: sliderStateCunstructor(-100, 79433),
@@ -305,7 +307,8 @@ const initialFinanceCondetion = {
   roa: sliderStateCunstructor(-275, 154),
   roe: sliderStateCunstructor(-4900, 1615),
   market_cap: sliderStateCunstructor(0, 435000),
-  activities_operating: sliderStateCunstructor(-13000, 68000),
-  activities_investing: sliderStateCunstructor(-54000, 5000),
-  activities_financing: sliderStateCunstructor(-15000, 26000),
+
+  operating: sliderStateCunstructor(-13000, 68000),
+  investing: sliderStateCunstructor(-54000, 5000),
+  financing: sliderStateCunstructor(-15000, 26000),
 };

--- a/src/pages/QuantLabPage/QuantModelTable/QuantModelTable.tsx
+++ b/src/pages/QuantLabPage/QuantModelTable/QuantModelTable.tsx
@@ -9,7 +9,10 @@ import {
   GridSelectionModel,
 } from "@mui/x-data-grid";
 import { useCallback, useMemo } from "react";
+import { useSelector } from "react-redux";
 
+import deleteQuantModel from "../../../apis/deleteQuantModel";
+import { RootState } from "../../../stores/store";
 import { VariableNameTranslate } from "../constants";
 import { IModel } from "../QuantLabPage";
 import SaveModelModal from "./SaveModelModal";
@@ -25,6 +28,8 @@ export default function QuantModelTable({
   setSelectionModel,
   setModelList,
 }: ModelListProps) {
+  const token = useSelector((state: RootState) => state.session.token);
+
   const columns: GridColDef[] = FIELDS.map((val) => {
     return {
       field: val,
@@ -36,9 +41,11 @@ export default function QuantModelTable({
 
   const deleteModel = useCallback(
     (id: GridRowId) => () => {
-      setTimeout(() => {
+      setTimeout(async () => {
         setModelList((prev) => prev.filter((model) => model.id !== id));
+
         // TODO: 백엔드 완료시 삭제 api 추가 #11
+        await deleteQuantModel(id as string, token);
       });
     },
     []

--- a/src/pages/QuantLabPage/QuantModelViewer/Chart.tsx
+++ b/src/pages/QuantLabPage/QuantModelViewer/Chart.tsx
@@ -63,7 +63,7 @@ export default function Chart({ charts }: ChartProps) {
 
 interface IRechartData {
   name: string;
-  kospi: number;
+  // kospi: number;
   [key: string]: string | number;
 }
 
@@ -78,15 +78,17 @@ const formatToRechartData = (charts: IChart[]): IRechartData[] => {
 
   const ret: IRechartData[] = [];
 
-  const graphDate = new Date(charts[0].chart_data["start_date"].split("T")[0]);
+  // const graphDate = new Date(charts[0].chart_data["start_date"].split("T")[0]);
+  const graphDate = new Date("2016-03-31T00:00:00.000Z".split("T")[0]); // TODO: 날짜 어떻게 할건지 정해야
   graphDate.setDate(1);
 
   const normalizedData = charts.map((val) => {
     return {
       ...val,
       chart_data: {
-        profit_kospi_data: kospiToBalance(val),
-        profit_rate_data: profitToBalance(val),
+        // profit_kospi_data: kospiToBalance(val),
+        // profit_rate_data: profitToBalance(val),
+        profit_rate_data: val.chart_data.profit_rate_data,
       },
     };
   });
@@ -96,9 +98,10 @@ const formatToRechartData = (charts: IChart[]): IRechartData[] => {
     idx < normalizedData[0].chart_data["profit_rate_data"].length;
     idx++
   ) {
-    const context: IRechartData = { name: "", kospi: 0 };
+    // const context: IRechartData = { name: "", kospi: 0 };
+    const context: IRechartData = { name: "" };
     context.name = yearAndMonthToString(graphDate);
-    context.kospi = normalizedData[0].chart_data["profit_kospi_data"][idx];
+    // context.kospi = normalizedData[0].chart_data["profit_kospi_data"][idx];
 
     normalizedData.forEach((data) => {
       context[data["model_name"]] = data.chart_data.profit_rate_data[idx];
@@ -111,53 +114,53 @@ const formatToRechartData = (charts: IChart[]): IRechartData[] => {
   return ret; // {name: string, kospi: number, 모델명:..., 모델명:...,}
 };
 
-function kospiToBalance(data: IChart) {
-  const normalizedKospiData = [];
-  const kospi: number[] = data.chart_data.profit_kospi_data;
-  const seed = 1000;
+// function kospiToBalance(data: IChart) {
+//   const normalizedKospiData = [];
+//   const kospi: number[] = data.chart_data.profit_kospi_data;
+//   const seed = 1000;
 
-  normalizedKospiData[0] = seed;
+//   normalizedKospiData[0] = seed;
 
-  for (let index = 1; index < kospi.length; index++) {
-    const kospiPropit = (kospi[index] - kospi[index - 1]) / kospi[index - 1];
-    normalizedKospiData[index] =
-      normalizedKospiData[index - 1] +
-      normalizedKospiData[index - 1] * kospiPropit;
-  }
+//   for (let index = 1; index < kospi.length; index++) {
+//     const kospiPropit = (kospi[index] - kospi[index - 1]) / kospi[index - 1];
+//     normalizedKospiData[index] =
+//       normalizedKospiData[index - 1] +
+//       normalizedKospiData[index - 1] * kospiPropit;
+//   }
 
-  const kospiPropit =
-    (kospi[kospi.length] - kospi[kospi.length - 1]) / kospi[kospi.length - 1];
+//   const kospiPropit =
+//     (kospi[kospi.length] - kospi[kospi.length - 1]) / kospi[kospi.length - 1];
 
-  const tmpBalace =
-    kospi[kospi.length] + (kospi[kospi.length] * kospiPropit) / 100;
+//   const tmpBalace =
+//     kospi[kospi.length] + (kospi[kospi.length] * kospiPropit) / 100;
 
-  normalizedKospiData.push(tmpBalace);
+//   normalizedKospiData.push(tmpBalace);
 
-  return normalizedKospiData;
-}
+//   return normalizedKospiData;
+// }
 
-const profitToBalance = (data: IChart) => {
-  const normalizedProfitData = [];
-  const profit: number[] = data.chart_data.profit_rate_data;
-  const seed = 1000;
+// const profitToBalance = (data: IChart) => {
+//   const normalizedProfitData = [];
+//   const profit: number[] = data.chart_data.profit_rate_data;
+//   const seed = 1000;
 
-  normalizedProfitData[0] = seed;
+//   normalizedProfitData[0] = seed;
 
-  for (let index = 1; index < profit.length; index++) {
-    normalizedProfitData[index] =
-      normalizedProfitData[index - 1] +
-      (normalizedProfitData[index - 1] * profit[index - 1]) / 100;
-  }
+//   for (let index = 1; index < profit.length; index++) {
+//     normalizedProfitData[index] =
+//       normalizedProfitData[index - 1] +
+//       (normalizedProfitData[index - 1] * profit[index - 1]) / 100;
+//   }
 
-  // 수익률 60개 -> 실제값 61개
-  const tmpBalace =
-    normalizedProfitData[profit.length - 1] +
-    (normalizedProfitData[profit.length - 1] * profit[profit.length - 1]) / 100;
+//   // 수익률 60개 -> 실제값 61개
+//   const tmpBalace =
+//     normalizedProfitData[profit.length - 1] +
+//     (normalizedProfitData[profit.length - 1] * profit[profit.length - 1]) / 100;
 
-  normalizedProfitData.push(tmpBalace);
+//   normalizedProfitData.push(tmpBalace);
 
-  return normalizedProfitData;
-};
+//   return normalizedProfitData;
+// };
 
 function yearAndMonthToString(date: Date) {
   let tmp: string;

--- a/src/stores/session.ts
+++ b/src/stores/session.ts
@@ -28,7 +28,7 @@ export const loginThunk = createAsyncThunk<
   },
   { email: string; password: string },
   { rejectValue: string }
->("user/login", async ({ email, password }, { rejectWithValue }) => {
+>("session/login", async ({ email, password }, { rejectWithValue }) => {
   try {
     const response = await login(email, password);
     if (response instanceof Error) throw response;

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -1,16 +1,26 @@
-import { configureStore } from "@reduxjs/toolkit";
+import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import logger from "redux-logger";
+import { persistReducer, persistStore } from "redux-persist";
+import storage from "redux-persist/lib/storage";
 
 import { sessionSlice } from "./session";
 
+const reducers = combineReducers({ session: sessionSlice.reducer });
+
+const persistConfig = {
+  key: "root",
+  storage,
+};
+
+const persistedReducer = persistReducer(persistConfig, reducers);
+
 export const store = configureStore({
-  reducer: {
-    session: sessionSlice.reducer,
-  },
+  reducer: persistedReducer,
   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(logger),
 });
+export const persistor = persistStore(store);
 
-// Infer the `RootState` and `AppDispatch` types from the store itself
+// // Infer the `RootState` and `AppDispatch` types from the store itself
 export type RootState = ReturnType<typeof store.getState>;
-// Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
+// // Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
 export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
### 주요 구현사항
* delete quant api 구현 및 적용하였습니다.
* redux-persist 라이브러리를 통해 새로고침시 로그인 유지 기능을 구현했습니다.

### 그 외 수정사항
* create quant api의 response 변화로 인한 에러들을 수정(임시조치)했습니다. #48 
* 네비게이션 로고의 "이코노미쿠스" 텍스트를 눌러도 이동하도록 수정했습니다.
* 메뉴 클릭시 가끔 이동하지 않는 버그(텍스트만 링크로 인식되기 때문)을 수정했습니다.

### 남은 이슈
get quant api의 백엔드 에러로 인해 상세페이지 작업을 하지 못했습니다. 주말까지 해보도록 하겠습니다.